### PR TITLE
fix(ci): add contents write permissions for docs and performance jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
-      contents: read
+      contents: write   # Required for pushing to gh-pages branch
       pages: write      # Required for GitHub Pages deployment
       id-token: write   # Required for GitHub Pages deployment
     
@@ -230,7 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
-      contents: read
+      contents: write   # Required for pushing benchmark data to gh-pages
       actions: write    # Required for benchmark action auto-push
       pull-requests: write  # Required for benchmark action comments
     


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions failures from run #16209410222 by adding missing `contents: write` permissions to jobs that need to push to the repository.

## Root Cause Analysis
The previous security fix (PR #43) added explicit permissions but was too restrictive:
- **Documentation job**: `peaceiris/actions-gh-pages@v4` needs `contents: write` to push to `gh-pages` branch
- **Performance job**: `benchmark-action/github-action-benchmark@v1` needs `contents: write` to push benchmark data

Both jobs were failing with:
```
remote: Permission to voidrunnerhq/voidrunner.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/voidrunnerhq/voidrunner.git/': The requested URL returned error: 403
```

## Changes Made
### Documentation Job (`docs`)
- ✅ Changed `contents: read` → `contents: write` 
- ✅ Kept `pages: write` and `id-token: write` for GitHub Pages
- ✅ Now can push documentation to `gh-pages` branch

### Performance Job (`performance`) 
- ✅ Changed `contents: read` → `contents: write`
- ✅ Kept `actions: write` and `pull-requests: write` for benchmark features
- ✅ Now can push benchmark data to `gh-pages` branch

## Security Impact
- ✅ Maintains principle of least privilege with minimal required permissions
- ✅ Each job only gets write access needed for its specific function
- ✅ Previous CodeQL security improvements remain intact
- ✅ No overly broad default permissions

## Test Plan
- [x] Updated permissions allow repository push access
- [x] Verified YAML syntax is valid
- [ ] CI run will validate both jobs can successfully push to `gh-pages`

Fixes #16209410222

🤖 Generated with [Claude Code](https://claude.ai/code)