### PR TITLE
docs: align documentation with current implementation status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,12 @@ voidrunner/
 ### Epic 2: Container Execution Engine ✅ **Complete**
 - **Issue #9**: Docker Client Integration and Security Configuration ✅ **Closed**
 - **Issue #10**: Task Execution Workflow and State Management ✅ **Closed**
-- **Issue #11**: Log Collection and Real-time Streaming 📋 **Open** (Priority 1)
+
+**Epic 2 Enhancements** (Non-blocking improvements)
+- **Issue #11**: Log Collection and Real-time Streaming 📋 **Open** (Priority 1) 
 - **Issue #12**: Error Handling and Cleanup Mechanisms 📋 **Open** (Priority 2)
+
+> **Note**: Issues #11-12 are enhancements to the completed Epic 2 functionality, not blockers. The core container execution engine with embedded workers is fully operational.
 
 ### Epic 3: Frontend Interface 📋 **Ready to Start**
 - **Issue #22**: Frontend Interface 📋 **Open**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,18 +6,21 @@ This document defines code style guidelines, review criteria, project-specific r
 
 VoidRunner is a distributed task execution platform designed for secure, scalable code execution. The project follows an incremental development approach through well-defined Epic milestones.
 
-### Current Implementation Status (Epic 1 ✅ Complete)
+### Current Implementation Status (Epic 1-2 ✅ Complete)
 - **Backend**: Go + Gin framework + PostgreSQL (pgx driver)
 - **API**: RESTful API with JWT authentication and comprehensive task management
 - **Database**: PostgreSQL with optimized schema and cursor pagination
+- **Container Execution**: Docker executor with comprehensive security controls
+- **Queue System**: Redis-based task queuing with retry logic and dead letter handling
+- **Worker Management**: Embedded worker pool with concurrency controls and health monitoring
 - **Testing**: 80%+ code coverage with unit and integration tests
 - **Documentation**: OpenAPI/Swagger specs with comprehensive examples
 
-### Planned Architecture (Epic 2-4 📋 Roadmap)
-- **Container Execution**: Docker + gVisor security for safe code execution
+### Planned Architecture (Epic 3-4 📋 Roadmap)
+- **Distributed Services**: Separate API and worker services for horizontal scaling
 - **Frontend**: Svelte + SvelteKit + TypeScript web interface
 - **Infrastructure**: Kubernetes (GKE) deployment with microservices
-- **Queue System**: Redis for task scheduling and real-time updates
+- **Log Streaming**: Real-time log collection and streaming
 - **Monitoring**: Real-time metrics, logging, and alerting systems
 
 ## Go Code Standards
@@ -29,8 +32,7 @@ voidrunner/
 ├── cmd/                    # Application entrypoints
 │   ├── api/               # ✅ API server main (implemented)
 │   ├── migrate/           # ✅ Database migration tool (implemented)
-│   ├── scheduler/         # 📋 Task scheduler main (planned - Epic 2)
-│   └── executor/          # 📋 Task executor main (planned - Epic 2)
+│   └── scheduler/         # ✅ Scheduler service main (implemented - for future distributed mode)
 ├── internal/              # Private application code
 │   ├── api/              # ✅ API handlers and routes (implemented)
 │   ├── auth/             # ✅ Authentication logic (implemented)
@@ -38,13 +40,13 @@ voidrunner/
 │   ├── database/         # ✅ Database layer (implemented)
 │   ├── models/           # ✅ Data models (implemented)
 │   ├── services/         # ✅ Business logic services (implemented)
-│   ├── executor/         # 📋 Task execution engine (planned - Epic 2)
-│   ├── queue/            # 📋 Message queue integration (planned - Epic 2)
-│   └── security/         # 📋 Security utilities (planned - Epic 2)
+│   ├── executor/         # ✅ Task execution engine (implemented)
+│   ├── queue/            # ✅ Redis queue integration (implemented)
+│   └── worker/           # ✅ Worker management (implemented)
 ├── pkg/                   # Public libraries
 │   ├── logger/           # ✅ Structured logging (implemented)
-│   ├── metrics/          # 📋 Prometheus metrics (planned - Epic 2)
-│   └── utils/            # 📋 Shared utilities (planned)
+│   ├── utils/            # ✅ Shared utilities (implemented)
+│   └── metrics/          # 📋 Prometheus metrics (planned - Epic 4)
 ├── api/                   # ✅ API specifications (OpenAPI) (implemented)
 ├── migrations/           # ✅ Database migrations (implemented)
 ├── tests/                # ✅ Integration tests (implemented)
@@ -63,11 +65,12 @@ voidrunner/
 - Comprehensive testing suite
 - OpenAPI documentation
 
-**Epic 2: Container Execution Engine** 🔄 **In Development**
-- Docker client integration with security
+**Epic 2: Container Execution Engine** ✅ **Complete**
+- Docker client integration with security controls
 - Task execution workflow and state management
-- Real-time log collection and streaming
-- Error handling and cleanup mechanisms
+- Embedded worker pool with concurrency management
+- Redis-based queue system with retry logic
+- Health monitoring and cleanup mechanisms
 
 **Epic 3: Frontend Interface** 📋 **Planned**
 - Svelte project setup and architecture
@@ -76,10 +79,49 @@ voidrunner/
 - Real-time task status updates
 
 **Epic 4: Advanced Features** 📋 **Planned**
+- Distributed services architecture (Issue #46)
+- Real-time log collection and streaming (Issue #11)
+- Enhanced error handling mechanisms (Issue #12)
 - Collaborative features and sharing
 - Advanced search and filtering
 - Real-time dashboard and system metrics
 - Advanced notifications and alerting
+
+## GitHub Issues Progress Tracking
+
+### Epic 1: Core API Infrastructure ✅ **Complete**
+- **Issue #3**: PostgreSQL Database Setup and Schema Design ✅ **Closed**
+- **Issue #4**: JWT Authentication System Implementation ✅ **Closed**
+- **Issue #5**: Task Management API Endpoints ✅ **Closed**
+- **Issue #6**: API Documentation and Testing Infrastructure ✅ **Closed**
+
+### Epic 2: Container Execution Engine ✅ **Complete**
+- **Issue #9**: Docker Client Integration and Security Configuration ✅ **Closed**
+- **Issue #10**: Task Execution Workflow and State Management ✅ **Closed**
+- **Issue #11**: Log Collection and Real-time Streaming 📋 **Open** (Priority 1)
+- **Issue #12**: Error Handling and Cleanup Mechanisms 📋 **Open** (Priority 2)
+
+### Epic 3: Frontend Interface 📋 **Ready to Start**
+- **Issue #22**: Frontend Interface 📋 **Open**
+- **Issue #23**: Svelte Project Setup and Architecture 📋 **Open** (Priority 0)
+- **Issue #24**: Authentication UI and User Management 📋 **Open** (Priority 0)
+- **Issue #25**: Task Creation and Management Interface 📋 **Open** (Priority 0)
+- **Issue #26**: Real-time Task Status Updates 📋 **Open** (Priority 0)
+- **Issue #27**: Real-time Features 📋 **Open**
+
+### Epic 4: Advanced Features 📋 **Future Work**
+- **Issue #28**: Real-time Dashboard and System Metrics 📋 **Open** (Priority 0)
+- **Issue #29**: Advanced Notifications and Alerting 📋 **Open** (Priority 1)
+- **Issue #30**: Advanced Search and Filtering 📋 **Open** (Priority 1)
+- **Issue #31**: Collaborative Features and Sharing 📋 **Open** (Priority 2)
+
+### Future Enhancements
+- **Issue #46**: Separate API and Worker Services for Horizontal Scaling 📋 **Open**
+  - This epic will transition from embedded workers to distributed services
+  - Currently tracked for future implementation when scaling requirements emerge
+
+### Current Focus
+With Epic 1-2 complete, the project has a fully functional task execution platform with embedded workers. The next logical step is Epic 3 (Frontend Interface) to provide a web-based user interface, followed by Epic 4 advanced features and eventual transition to distributed services (Issue #46).
 
 ### Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ VoidRunner is designed to safely execute user-submitted code in isolated contain
 - **REST API**: Comprehensive HTTP API with 16+ endpoints for complete task lifecycle management
 - **JWT Authentication**: Secure user authentication with access and refresh tokens
 - **Task Management**: Full CRUD operations for code tasks with metadata support
-- **Task Execution**: Asynchronous task execution with embedded or distributed worker architecture
+- **Task Execution**: Asynchronous task execution with embedded worker architecture
 - **Container Security**: Docker-based execution with seccomp, resource limits, and isolation
 - **Queue System**: Redis-based task queuing with priority support and retry logic
+- **Worker Management**: Embedded worker pool with concurrency controls and health monitoring
 - **Real-time Monitoring**: Health checks, worker status endpoints, and execution metrics
-- **Flexible Deployment**: Embedded workers for development or separate services for production
 - **Database Integration**: PostgreSQL with optimized schema and cursor pagination
 - **Security**: Input validation, rate limiting, and secure request handling
 - **Testing**: 80%+ code coverage with unit and integration tests
@@ -23,7 +23,7 @@ VoidRunner is designed to safely execute user-submitted code in isolated contain
 
 ## System Architecture
 
-### Embedded Workers (Development/Small Scale) ✅ Complete
+### Current Implementation (Embedded Workers)
 ```
 ┌─────────────────┐    ┌─────────────────────────────────┐    ┌─────────────────┐
 │   Web Clients   │    │        API Server               │    │   PostgreSQL    │
@@ -37,33 +37,15 @@ VoidRunner is designed to safely execute user-submitted code in isolated contain
                        │  │   - Task Processing     │    │    │                 │
                        │  │   - Docker Execution    │    │    └─────────────────┘
                        │  │   - Health Monitoring   │    │
-                       │  └─────────────────────────┘    │    ┌─────────────────┐
-                       └─────────────────────────────────┘◄──►│     Docker      │
-                                                               │   (Containers)  │
+                       │  │   - Concurrency Control │    │    ┌─────────────────┐
+                       │  └─────────────────────────┘    │◄──►│     Docker      │
+                       └─────────────────────────────────┘    │   (Containers)  │
                                                                │                 │
                                                                └─────────────────┘
 ```
 
-### Distributed Services (Production/Scale) ✅ Complete
-```
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   Web Clients   │    │   API Server     │    │   PostgreSQL    │    │     Redis       │
-│  (Postman/curl) │◄──►│   - HTTP API     │◄──►│    Database     │◄──►│   (Queues)      │
-│                 │    │   - Auth         │    │                 │    │                 │
-└─────────────────┘    │   - Task Mgmt    │    └─────────────────┘    └─────────────────┘
-                       └──────────────────┘                                    ▲
-                                                                               │
-                       ┌──────────────────┐    ┌─────────────────┐            │
-                       │ Scheduler Service│◄──►│     Docker      │            │
-                       │  - Worker Pools  │    │   (Containers)  │            │
-                       │  - Task Execution│    │                 │            │
-                       │  - Auto-scaling  │    └─────────────────┘            │
-                       └──────────────────┘                                   │
-                                ▲                                             │
-                                └─────────────────────────────────────────────┘
-```
-
-### Future Extensions (📋 Roadmap)
+### Future Roadmap
+- **Distributed Services**: Separate API and worker services for horizontal scaling
 - **Svelte Web UI**: Modern frontend interface
 - **Kubernetes Deployment**: Container orchestration
 - **Multi-language Support**: Additional runtime environments
@@ -71,7 +53,7 @@ VoidRunner is designed to safely execute user-submitted code in isolated contain
 
 ## Quick Start
 
-### Development Mode (Embedded Workers)
+### Development Mode
 
 The fastest way to get started with VoidRunner:
 
@@ -91,28 +73,28 @@ This starts VoidRunner with embedded workers on http://localhost:8080
 - Worker Status: http://localhost:8080/health/workers
 - API Documentation: http://localhost:8080/docs
 
-### Production Mode (Distributed Services)
+### Production Mode
 
-For production deployments with horizontal scaling:
+For production deployments:
 
 ```bash
 # Using Docker Compose
-./scripts/docker-deploy.sh -m prod up
+docker-compose -f docker-compose.yml up -d
 
-# Or manually
-SERVER_ENV=production EMBEDDED_WORKERS=false ./bin/api
-SERVER_ENV=production ./bin/scheduler
+# Or build and run manually
+make build
+SERVER_ENV=production ./bin/api
 ```
 
 ### Configuration Modes
 
-VoidRunner supports three deployment configurations:
+VoidRunner currently supports embedded worker architecture:
 
-| Mode | Use Case | Workers | Scaling | Setup |
-|------|----------|---------|---------|-------|
-| **Development** | Local development | Embedded | Single process | `EMBEDDED_WORKERS=true` |
-| **Production** | Enterprise deployment | Separate service | Horizontal | `EMBEDDED_WORKERS=false` |
-| **Test** | CI/CD and testing | Embedded | Single process | `SERVER_ENV=test` |
+| Mode | Use Case | Workers | Configuration |
+|------|----------|---------|---------------|
+| **Development** | Local development | Embedded | Relaxed security, debug logging |
+| **Production** | Production deployment | Embedded | Enhanced security, structured logging |
+| **Test** | CI/CD and testing | Embedded | Mock executors, test database |
 
 ## API Endpoints
 
@@ -138,7 +120,8 @@ VoidRunner supports three deployment configurations:
 - `DELETE /api/v1/executions/{id}` - Cancel execution
 
 ### System Health
-- `GET /health` - Health check endpoint
+- `GET /health` - API health check endpoint
+- `GET /health/workers` - Embedded worker status and metrics
 - `GET /ready` - Readiness check endpoint
 
 ## Quick Start
@@ -147,7 +130,8 @@ VoidRunner supports three deployment configurations:
 
 - Go 1.24.4+ installed
 - PostgreSQL 15+ (for database operations)
-- Docker (for containerization and testing)
+- Redis 7+ (for task queuing)
+- Docker (for containerization and task execution)
 
 ### Setup
 
@@ -245,14 +229,14 @@ make docs-serve
 ### Phase 1: Core Infrastructure ✅ Complete
 Task management API with authentication, database integration, and comprehensive testing.
 
-### Phase 2: Container Execution Engine 🔄 In Development
-Secure Docker-based code execution with resource limiting, real-time log streaming, and safety controls.
+### Phase 2: Container Execution Engine ✅ Complete
+Secure Docker-based code execution with embedded workers, resource limiting, and safety controls.
 
 ### Phase 3: Web Interface 📋 Planned
 Modern Svelte-based frontend with real-time task monitoring, code editor, and user dashboard.
 
 ### Phase 4: Advanced Features 📋 Planned
-Collaborative features, advanced search and filtering, system metrics dashboard, and notification system.
+Distributed services, collaborative features, advanced search and filtering, and real-time log streaming.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ VoidRunner is designed to safely execute user-submitted code in isolated contain
 ## System Architecture
 
 ### Current Implementation (Embedded Workers)
+Single-process architecture with embedded worker pool for development and production
+
 ```
 ┌─────────────────┐    ┌─────────────────────────────────┐    ┌─────────────────┐
 │   Web Clients   │    │        API Server               │    │   PostgreSQL    │
@@ -37,11 +39,12 @@ VoidRunner is designed to safely execute user-submitted code in isolated contain
                        │  │   - Task Processing     │    │    │                 │
                        │  │   - Docker Execution    │    │    └─────────────────┘
                        │  │   - Health Monitoring   │    │
-                       │  │   - Concurrency Control │    │    ┌─────────────────┐
-                       │  └─────────────────────────┘    │◄──►│     Docker      │
-                       └─────────────────────────────────┘    │   (Containers)  │
-                                                               │                 │
-                                                               └─────────────────┘
+                       │  │   - Concurrency Control │    │
+                       │  └─────────────────────────┘    │    ┌─────────────────┐
+                       └─────────────────────────────────┘◄──►│     Docker      │
+                                                              │   (Containers)  │
+                                                              │                 │
+                                                              └─────────────────┘
 ```
 
 ### Future Roadmap
@@ -89,6 +92,8 @@ SERVER_ENV=production ./bin/api
 ### Configuration Modes
 
 VoidRunner currently supports embedded worker architecture:
+
+> **Note**: Distributed services (Issue #46) planned for future horizontal scaling needs
 
 | Mode | Use Case | Workers | Configuration |
 |------|----------|---------|---------------|


### PR DESCRIPTION
## Summary
This PR aligns our documentation with the actual implementation status after completing Issue #10. The docs were incorrectly suggesting we had distributed services working, when in reality we have excellent embedded workers implementation.

## Key Changes

### README.md (Public Document)
- ✅ **Accurate Architecture**: Updated to show single-process embedded workers only
- ✅ **Corrected Features**: Removed claims about distributed/horizontal scaling
- ✅ **Updated Prerequisites**: Added Redis requirement
- ✅ **Realistic Deployment**: Both dev and prod use embedded workers (not separate services)
- ✅ **Honest Roadmap**: Phase 2 marked complete, distributed services moved to future

### CLAUDE.md (Internal Document) 
- ✅ **Epic Status Correction**: Epic 2 marked as Complete (was incorrectly "In Development")
- ✅ **GitHub Issues Tracking**: Added comprehensive progress section with all issues
- ✅ **Implementation Reality**: Updated project structure to reflect what's actually built
- ✅ **Future Planning**: Issue #46 properly positioned as future distributed work

## What's Actually Working ✅
- Complete embedded worker system with Redis queuing
- Docker executor with comprehensive security controls  
- Worker pool management with concurrency controls
- Health monitoring and background cleanup
- Retry logic and dead letter queue handling

## What's Future Work 📋
- **Issue #46**: Distributed services (separate API and worker processes)
- **Issue #11**: Real-time log streaming
- **Issue #12**: Enhanced error handling
- **Epic 3**: Frontend interface

## Accuracy Principles Applied
- **No overselling**: Only document what actually works
- **Clear separation**: README for users, CLAUDE.md for development
- **Honest roadmap**: Embedded workers are the current reality
- **Future clarity**: Issue #46 tracks distributed architecture

This ensures users and contributors have accurate expectations about VoidRunner's current capabilities and future direction.

🤖 Generated with [Claude Code](https://claude.ai/code)