### PR TITLE
fix(dev): resolve Redis connection issue in development environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: voidrunner
       POSTGRES_PASSWORD: voidrunner_dev_password
     networks:
-      - voidrunner-dev
+      - voidrunner-backend
     deploy:
       resources:
         limits:
@@ -23,7 +23,7 @@ services:
     container_name: voidrunner-redis-dev
     command: redis-server --appendonly yes  # Remove memory limits for dev
     networks:
-      - voidrunner-dev
+      - voidrunner-backend
     deploy:
       resources:
         limits:
@@ -47,6 +47,12 @@ services:
       DB_PASSWORD: voidrunner_dev_password
       DB_NAME: voidrunner_dev
       DB_SSL_MODE: disable
+      
+      # Redis Configuration (Development)
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      REDIS_PASSWORD: ""
+      REDIS_DATABASE: "0"
       
       # Queue Configuration (Development)
       QUEUE_TASK_QUEUE_NAME: "voidrunner:tasks:dev"
@@ -82,7 +88,7 @@ services:
       - .:/app/src:ro
     
     networks:
-      - voidrunner-dev
+      - voidrunner-backend
     
     restart: unless-stopped
     
@@ -96,5 +102,5 @@ services:
           cpus: '0.25'
 
 networks:
-  voidrunner-dev:
+  voidrunner-backend:
     driver: bridge


### PR DESCRIPTION
## Summary

This PR fixes the Redis connection issue in the development environment that was causing the `make dev-up` command to fail. The API server was unable to connect to Redis due to incorrect network configuration and missing environment variables.

## Problem

- The `make dev-up` command was failing with Redis connection errors
- API container was trying to connect to Redis at `localhost` instead of the Docker service name
- Network configuration mismatch between base and development Docker Compose files
- Missing Redis environment variables in the development override file

## Solution

**Key changes in `docker-compose.dev.yml`:**

1. **Added Redis Environment Variables:**
   - `REDIS_HOST: redis` - Use Docker service name instead of localhost
   - `REDIS_PORT: "6379"` - Explicit port configuration
   - `REDIS_PASSWORD: ""` - Empty password for development
   - `REDIS_DATABASE: "0"` - Default database

2. **Fixed Network Configuration:**
   - Changed from `voidrunner-dev` to `voidrunner-backend` network
   - Ensures consistent network naming across all compose files
   - Proper service discovery within Docker network

## Testing

✅ **Verified Fix:**
- `make dev-up` now starts successfully without Redis connection errors
- API logs show `"Redis ping successful","result":"PONG"`
- Database connection working: `"database connection pool created successfully"`
- Queue manager starts properly: `"starting queue manager"`
- Redis pool stats show healthy connections (6 idle connections, 0 timeouts)

**Test Results:**
```
{"time":"2025-07-14T15:25:55.080648034Z","level":"DEBUG","msg":"Redis ping successful","result":"PONG"}
{"time":"2025-07-14T15:25:55.080777201Z","level":"DEBUG","msg":"Redis pool stats","hits":0,"misses":1,"timeouts":0,"total_conns":6,"idle_conns":6,"stale_conns":0}
{"time":"2025-07-14T15:25:55.080826701Z","level":"INFO","msg":"starting queue manager"}
```

## Files Changed

- `docker-compose.dev.yml`: Added Redis environment variables and fixed network configuration

## Impact

- Development environment (`make dev-up`) now works reliably
- Redis-based queue system functions properly in development
- Embedded workers can connect to Redis queues
- Consistent network configuration across all services

This fix resolves the Redis connection issues and ensures the development environment works as expected.

🤖 Generated with [Claude Code](https://claude.ai/code)